### PR TITLE
Update standard_library.py

### DIFF
--- a/src/main/resources/META-INF/resources/python/foundry_api/standard_library.py
+++ b/src/main/resources/META-INF/resources/python/foundry_api/standard_library.py
@@ -22,7 +22,7 @@ def _init(context):
 
 
 def _platform_variant():
-    return 'arm' if 'aarch' in platform.machine() else 'x64'
+    return 'arm' if 'arm' in _platform.machine() else 'arm' if 'aarch' in _platform.machine() else 'x64'
 
 
 class _DaemonClient:

--- a/src/main/resources/META-INF/resources/python/foundry_api/standard_library.py
+++ b/src/main/resources/META-INF/resources/python/foundry_api/standard_library.py
@@ -22,7 +22,7 @@ def _init(context):
 
 
 def _platform_variant():
-    return 'arm' if 'arm' in _platform.machine() else 'x64'
+    return 'arm' if 'aarch' in platform.machine() else 'x64'
 
 
 class _DaemonClient:


### PR DESCRIPTION
This change should fix the Lava lamp not working. The platform variant is returning a different value on an ARM device